### PR TITLE
feat(eslint): add unocss wrapper config support

### DIFF
--- a/.changeset/olive-ideas-type.md
+++ b/.changeset/olive-ideas-type.md
@@ -1,0 +1,5 @@
+---
+'@icebreakers/eslint-config': patch
+---
+
+feat(eslint): add unocss wrapper config support

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -53,6 +53,9 @@ export default icebreaker({
   tailwindcss: {
     tailwindConfig: './tailwind.config.ts',
   },
+  unocss: {
+    strict: true,
+  },
   mdx: process.env.LINT_MDX === 'true',
   a11y: true,
   nestjs: true,
@@ -67,6 +70,7 @@ export default icebreaker({
 - `react` – defers to the upstream React preset and unlocks accessibility helpers when `a11y` is enabled. The required React lint plugins are bundled with this package.
 - `query` – toggles the TanStack Query plugin (`@tanstack/eslint-plugin-query`) and its recommended lint rules. Missing plugin installs are treated as a no-op.
 - `tailwindcss` – pass `true` to use the built-in Tailwind flat config or provide `{ entryPoint, tailwindConfig }` for Tailwind v4/v3 projects.
+- `unocss` – pass `true` to use the upstream Antfu UnoCSS preset, or provide `{ strict, attributify, configPath }` to keep the same preset while using the Icebreaker wrapper API.
 - `mdx` – activates MDX linting via `eslint-plugin-mdx`.
 - `a11y` – wires in JSX (React) and Vue accessibility plugins. Missing framework-specific plugins are skipped independently.
 - `typescript` – extends the TypeScript preset and applies stricter unused diagnostics. Pair with `nestjs` for Nest specific adjustments.
@@ -162,6 +166,36 @@ export default icebreaker({
 the `@icebreakers/stylelint-config` options (`presets`, `tailwindcssPreset`,
 `ignores`, `extends`, `overrides`, `rules`).
 
+### UnoCSS Projects
+
+The UnoCSS integration is still powered by the upstream Antfu preset, but
+`@icebreakers/eslint-config` adds a small wrapper so the config file path can be
+declared next to the other UnoCSS options:
+
+```ts
+import path from 'node:path'
+import { icebreaker } from '@icebreakers/eslint-config'
+
+export default icebreaker({
+  unocss: {
+    strict: true,
+    attributify: false,
+    configPath: path.resolve(process.cwd(), './uno.config.ts'),
+  },
+})
+```
+
+Behavior details:
+
+- `unocss: true` enables the upstream Antfu UnoCSS preset unchanged.
+- `unocss.configPath` is an Icebreaker wrapper for `settings.unocss.configPath`.
+- If `configPath` is omitted, UnoCSS still searches the lint project root for
+  `uno.config.*`.
+- If both `unocss.configPath` and `settings.unocss.configPath` are provided,
+  `unocss.configPath` wins.
+- If `@unocss/eslint-plugin` is unavailable, the UnoCSS preset is skipped
+  instead of throwing.
+
 ### NestJS Projects
 
 Enable `nestjs: true` together with the TypeScript preset to apply rules tailored for Nest idioms:
@@ -198,6 +232,6 @@ You may also pass other flat configs (e.g. from in-house presets) as additional 
 
 ## Troubleshooting
 
-- Missing plugin errors usually mean a feature is enabled without its optional dependency being installed in the current workspace. React and Next related presets now auto-skip in that case; other features can be added with `pnpm add -D`.
+- Missing plugin errors usually mean a feature is enabled without its optional dependency being installed in the current workspace. React, Next, and UnoCSS related presets now auto-skip in that case; other features can be added with `pnpm add -D`.
 - When combining legacy `.eslintrc` projects, prefer `icebreakerLegacy()` and move overrides into flat config format incrementally.
 - Tailwind class validation reads from your `tailwind.config.*`; double check the path when using monorepo roots or custom build tooling.

--- a/packages/eslint/README.zh.md
+++ b/packages/eslint/README.zh.md
@@ -1,5 +1,33 @@
 # @icebreakers/eslint-config
 
+## UnoCSS 包装层
+
+`@icebreakers/eslint-config` 的 UnoCSS 能力仍然复用上游
+`@antfu/eslint-config`，但现在额外提供了一层更贴近本仓库风格的包装 API。
+
+推荐写法：
+
+```ts
+import path from 'node:path'
+import { icebreaker } from '@icebreakers/eslint-config'
+
+export default icebreaker({
+  unocss: {
+    strict: true,
+    attributify: false,
+    configPath: path.resolve(process.cwd(), './uno.config.ts'),
+  },
+})
+```
+
+行为说明：
+
+- `unocss: true`：直接启用上游 Antfu 的 UnoCSS preset
+- `unocss.configPath`：会被自动映射为 `settings.unocss.configPath`
+- 不传 `configPath`：仍然按 UnoCSS 默认行为，从 lint 项目根目录查找 `uno.config.*`
+- 同时传 `unocss.configPath` 和 `settings.unocss.configPath`：以前者为准
+- 如果当前 workspace 没有安装 `@unocss/eslint-plugin`：该 preset 会自动跳过，不会直接抛错
+
 ## 简介
 
 `@icebreakers/eslint-config` 基于 `@antfu/eslint-config` 的 flat config 预设，额外补充了 Tailwind CSS、MDX、Vue 无障碍以及 Icebreaker 团队常用的 TypeScript 默认规则。它返回一个 `FlatConfigComposer`，可以按需启用不同预设，并继续追加工作区特定的覆盖项。

--- a/packages/eslint/index.d.ts
+++ b/packages/eslint/index.d.ts
@@ -14,14 +14,21 @@ export interface TailwindcssOption {
 }
 
 export type TailwindcssConfig = boolean | TailwindcssOption
+export interface UnocssOption {
+  configPath?: string
+  attributify?: boolean
+  strict?: boolean
+}
+export type UnocssConfig = boolean | UnocssOption
 export interface StylelintBridgeOption extends IcebreakerStylelintOptions {
   cwd?: string
 }
 export type StylelintBridgeConfig = boolean | StylelintBridgeOption
 
-export type UserDefinedOptions = OptionsConfig & TypedFlatConfigItem & {
+export type UserDefinedOptions = Omit<OptionsConfig, 'unocss'> & TypedFlatConfigItem & {
   miniProgram?: boolean
   tailwindcss?: TailwindcssConfig
+  unocss?: UnocssConfig
   stylelint?: StylelintBridgeConfig
   mdx?: boolean
   a11y?: boolean

--- a/packages/eslint/src/factory.ts
+++ b/packages/eslint/src/factory.ts
@@ -21,12 +21,62 @@ const OPTIONAL_ANTFU_FEATURE_PACKAGES = {
     'eslint-plugin-react-refresh',
   ],
   nextjs: ['@next/eslint-plugin-next'],
+  unocss: ['@unocss/eslint-plugin'],
 } as const
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && Object.prototype.toString.call(value) === '[object Object]'
+}
+
+function cloneUserDefinedOptions(
+  options: UserDefinedOptions,
+): UserDefinedOptions {
+  const { settings, ...restOptions } = options
+  if (settings === undefined) {
+    return { ...restOptions }
+  }
+
+  return {
+    ...restOptions,
+    settings,
+  }
+}
+
+function getSettingsRecord(
+  settings: UserDefinedOptions['settings'],
+): Record<string, unknown> {
+  return isPlainObject(settings) ? settings : {}
+}
+
+function removeNamespacedSetting(
+  options: UserDefinedOptions,
+  namespace: string,
+): UserDefinedOptions {
+  if (!isPlainObject(options.settings)) {
+    return options
+  }
+
+  const settings = getSettingsRecord(options.settings)
+  if (!(namespace in settings)) {
+    return options
+  }
+
+  const { [namespace]: _unusedNamespace, ...restSettings } = settings
+  const { settings: _settings, ...restOptions } = options
+  if (Object.keys(restSettings).length === 0) {
+    return { ...restOptions }
+  }
+
+  return {
+    ...restOptions,
+    settings: restSettings as NonNullable<UserDefinedOptions['settings']>,
+  }
+}
 
 function normalizeOptionalAntfuFeatures(
   options: UserDefinedOptions,
 ): UserDefinedOptions {
-  const normalized = { ...options }
+  const normalized = cloneUserDefinedOptions(options)
 
   if (normalized.react && !hasAllPackages([...OPTIONAL_ANTFU_FEATURE_PACKAGES.react])) {
     normalized.react = false
@@ -36,7 +86,61 @@ function normalizeOptionalAntfuFeatures(
     normalized.nextjs = false
   }
 
+  if (normalized.unocss && !hasAllPackages([...OPTIONAL_ANTFU_FEATURE_PACKAGES.unocss])) {
+    normalized.unocss = false
+    return removeNamespacedSetting(normalized, 'unocss')
+  }
+
   return normalized
+}
+
+function mergeNamespacedSetting(
+  options: UserDefinedOptions,
+  namespace: string,
+  value: Record<string, unknown>,
+): UserDefinedOptions {
+  const currentSettings = getSettingsRecord(options.settings)
+  const currentNamespaceSettings = isPlainObject(currentSettings[namespace])
+    ? currentSettings[namespace]
+    : {}
+
+  return {
+    ...options,
+    settings: {
+      ...currentSettings,
+      [namespace]: {
+        ...currentNamespaceSettings,
+        ...value,
+      },
+    } as NonNullable<UserDefinedOptions['settings']>,
+  }
+}
+
+function normalizeUnoCssOptions(
+  options: UserDefinedOptions,
+): UserDefinedOptions {
+  if (!options.unocss || typeof options.unocss !== 'object') {
+    return options
+  }
+
+  const { configPath, ...unocssOptions } = options.unocss
+  const { settings, ...restOptions } = options
+  const normalized: UserDefinedOptions = settings === undefined
+    ? {
+        ...restOptions,
+        unocss: unocssOptions,
+      }
+    : {
+        ...restOptions,
+        settings: settings as NonNullable<UserDefinedOptions['settings']>,
+        unocss: unocssOptions,
+      }
+
+  if (!configPath) {
+    return normalized
+  }
+
+  return mergeNamespacedSetting(normalized, 'unocss', { configPath })
 }
 
 function hasGlobalIgnoreShape(
@@ -108,8 +212,9 @@ export function icebreaker(
   ...userConfigs: UserConfigItem[]
 ): FlatConfigComposer<TypedFlatConfigItem, ConfigNames> {
   const [resolved, ...presets] = getPresets(options)
+  const normalized = normalizeUnoCssOptions(normalizeOptionalAntfuFeatures(resolved))
   return antfu(
-    normalizeOptionalAntfuFeatures(resolved),
+    normalized,
     ...presets,
     ...userConfigs.map(normalizeUserConfig),
   )
@@ -122,8 +227,9 @@ export function icebreakerLegacy(
   ...userConfigs: UserConfigItem[]
 ): FlatConfigComposer<TypedFlatConfigItem, ConfigNames> {
   const [resolved, ...presets] = getPresets(options, 'legacy')
+  const normalized = normalizeUnoCssOptions(normalizeOptionalAntfuFeatures(resolved))
   return antfu(
-    normalizeOptionalAntfuFeatures(resolved),
+    normalized,
     ...presets,
     ...userConfigs.map(normalizeUserConfig),
   )

--- a/packages/eslint/src/factory.ts
+++ b/packages/eslint/src/factory.ts
@@ -132,7 +132,7 @@ function normalizeUnoCssOptions(
       }
     : {
         ...restOptions,
-        settings: settings as NonNullable<UserDefinedOptions['settings']>,
+        settings,
         unocss: unocssOptions,
       }
 

--- a/packages/eslint/src/index.ts
+++ b/packages/eslint/src/index.ts
@@ -5,6 +5,8 @@ export type {
   StylelintBridgeOption,
   TailwindcssConfig,
   TailwindcssOption,
+  UnocssConfig,
+  UnocssOption,
   UserConfigItem,
   UserDefinedOptions,
 } from './types'

--- a/packages/eslint/src/types.ts
+++ b/packages/eslint/src/types.ts
@@ -19,6 +19,22 @@ export interface TailwindcssOption {
 }
 
 export type TailwindcssConfig = boolean | TailwindcssOption
+export interface UnocssOption {
+  /**
+   * UnoCSS config file path, e.g. `uno.config.ts`.
+   * When omitted, fallback to default project-root discovery.
+   */
+  configPath?: string
+  /**
+   * Enable UnoCSS attributify support.
+   */
+  attributify?: boolean
+  /**
+   * Enable UnoCSS strict mode.
+   */
+  strict?: boolean
+}
+export type UnocssConfig = boolean | UnocssOption
 export interface StylelintBridgeOption extends IcebreakerStylelintOptions {
   cwd?: string
 }
@@ -35,7 +51,7 @@ export type NormalizableUserConfig = Exclude<
   FlatConfigComposer<any, any>
 >
 
-export type UserDefinedOptions = OptionsConfig & TypedFlatConfigItem & {
+export type UserDefinedOptions = Omit<OptionsConfig, 'unocss'> & TypedFlatConfigItem & {
   /**
    * Enable Mini Program support.
    * @default false
@@ -46,6 +62,11 @@ export type UserDefinedOptions = OptionsConfig & TypedFlatConfigItem & {
    * @default false
    */
   tailwindcss?: TailwindcssConfig
+  /**
+   * Enable UnoCSS support.
+   * @default false
+   */
+  unocss?: UnocssConfig
   /**
    * Bridge Stylelint diagnostics into ESLint for style files.
    * @default false

--- a/packages/eslint/test-d/index.test-d.ts
+++ b/packages/eslint/test-d/index.test-d.ts
@@ -14,6 +14,14 @@ expectAssignable<FlatConfigComposer<TypedFlatConfigItem, ConfigNames>>(icebreake
 expectAssignable<FlatConfigComposer<TypedFlatConfigItem, ConfigNames>>(icebreakerLegacy())
 expectAssignable<UserDefinedOptions>({ miniProgram: true })
 expectAssignable<UserDefinedOptions>({ weapp: true })
+expectAssignable<UserDefinedOptions>({ unocss: true })
+expectAssignable<UserDefinedOptions>({
+  unocss: {
+    strict: true,
+    attributify: false,
+    configPath: './uno.config.ts',
+  },
+})
 expectType<IcebreakerEslintConfig>(icebreaker())
 expectType<IcebreakerLegacyEslintConfig>(icebreakerLegacy())
 expectType<[UserDefinedOptions, ...UserConfigItem[]]>(getPresets())

--- a/packages/eslint/test/eslint.integration.test.ts
+++ b/packages/eslint/test/eslint.integration.test.ts
@@ -406,4 +406,84 @@ describe('eslint integration fixtures', () => {
     ]))
     expect(result?.messages.some(message => message.ruleId === 'no-undef')).toBe(false)
   })
+
+  it('discovers uno.config.ts from project root when unocss.configPath is omitted', async () => {
+    const tempDir = path.join(TEMP_ROOT, `unocss-root-${crypto.randomUUID()}`)
+    await fs.rm(tempDir, { recursive: true, force: true })
+    await fs.mkdir(tempDir, { recursive: true })
+    await fs.writeFile(
+      path.join(tempDir, 'uno.config.ts'),
+      `export default { blocklist: ['foo'] }\n`,
+      'utf8',
+    )
+
+    const eslint = new ESLint({
+      cwd: tempDir,
+      overrideConfig: await icebreaker({
+        unocss: {
+          strict: true,
+        },
+      }).toConfigs(),
+      overrideConfigFile: true,
+    })
+
+    const [result] = await eslint.lintText(
+      `export const Demo = () => <div className="foo bar" />\n`,
+      {
+        filePath: path.join(tempDir, 'demo.jsx'),
+      },
+    )
+
+    expect(result?.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        ruleId: 'unocss/blocklist',
+        message: expect.stringContaining('"foo" is in blocklist'),
+      }),
+    ]))
+  })
+
+  it('uses unocss.configPath to override root uno.config.ts', async () => {
+    const tempDir = path.join(TEMP_ROOT, `unocss-config-path-${crypto.randomUUID()}`)
+    const customConfigPath = path.resolve(tempDir, 'configs', 'uno.alt.ts')
+
+    await fs.rm(tempDir, { recursive: true, force: true })
+    await fs.mkdir(path.dirname(customConfigPath), { recursive: true })
+
+    await fs.writeFile(
+      path.join(tempDir, 'uno.config.ts'),
+      `export default { blocklist: ['foo'] }\n`,
+      'utf8',
+    )
+    await fs.writeFile(
+      customConfigPath,
+      `export default { blocklist: ['bar'] }\n`,
+      'utf8',
+    )
+
+    const eslint = new ESLint({
+      cwd: tempDir,
+      overrideConfig: await icebreaker({
+        unocss: {
+          strict: true,
+          configPath: customConfigPath,
+        },
+      }).toConfigs(),
+      overrideConfigFile: true,
+    })
+
+    const [result] = await eslint.lintText(
+      `export const Demo = () => <div className="foo bar" />\n`,
+      {
+        filePath: path.join(tempDir, 'demo.jsx'),
+      },
+    )
+
+    expect(result?.messages.some(message => message.message.includes('"foo" is in blocklist'))).toBe(false)
+    expect(result?.messages).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        ruleId: 'unocss/blocklist',
+        message: expect.stringContaining('"bar" is in blocklist'),
+      }),
+    ]))
+  })
 })

--- a/packages/eslint/test/factory.unit.test.ts
+++ b/packages/eslint/test/factory.unit.test.ts
@@ -116,4 +116,241 @@ describe('factory helpers', () => {
       { name: 'preset' },
     )
   })
+
+  it('disables optional antfu unocss feature when the plugin is unavailable', () => {
+    getPresetsMock.mockReturnValueOnce([
+      {
+        unocss: true,
+      } as any,
+      { name: 'preset' },
+    ])
+    hasAllPackagesMock.mockImplementation((packages) => {
+      return !packages.includes('@unocss/eslint-plugin')
+    })
+
+    icebreaker({
+      unocss: true,
+    } as any)
+
+    expect(antfuMock).toHaveBeenCalledWith(
+      {
+        unocss: false,
+      },
+      { name: 'preset' },
+    )
+  })
+
+  it('maps unocss.configPath to settings.unocss.configPath', () => {
+    getPresetsMock.mockReturnValueOnce([
+      {
+        unocss: {
+          strict: true,
+          attributify: false,
+          configPath: './uno.config.ts',
+        },
+      } as any,
+      { name: 'preset' },
+    ])
+
+    icebreaker({
+      unocss: {
+        strict: true,
+        attributify: false,
+        configPath: './uno.config.ts',
+      },
+    } as any)
+
+    expect(antfuMock).toHaveBeenCalledWith(
+      {
+        unocss: {
+          strict: true,
+          attributify: false,
+        },
+        settings: {
+          unocss: {
+            configPath: './uno.config.ts',
+          },
+        },
+      },
+      { name: 'preset' },
+    )
+  })
+
+  it('keeps default unocss discovery behavior when configPath is omitted', () => {
+    getPresetsMock.mockReturnValueOnce([
+      {
+        unocss: {
+          strict: true,
+          attributify: false,
+        },
+      } as any,
+      { name: 'preset' },
+    ])
+
+    icebreaker({
+      unocss: {
+        strict: true,
+        attributify: false,
+      },
+    } as any)
+
+    expect(antfuMock).toHaveBeenCalledWith(
+      {
+        unocss: {
+          strict: true,
+          attributify: false,
+        },
+      },
+      { name: 'preset' },
+    )
+  })
+
+  it('prefers wrapper configPath over settings.unocss.configPath', () => {
+    getPresetsMock.mockReturnValueOnce([
+      {
+        unocss: {
+          strict: true,
+          configPath: './preferred-uno.config.ts',
+        },
+        settings: {
+          unocss: {
+            configPath: './ignored-uno.config.ts',
+          },
+        },
+      } as any,
+      { name: 'preset' },
+    ])
+
+    icebreaker({
+      unocss: {
+        strict: true,
+        configPath: './preferred-uno.config.ts',
+      },
+      settings: {
+        unocss: {
+          configPath: './ignored-uno.config.ts',
+        },
+      },
+    } as any)
+
+    expect(antfuMock).toHaveBeenCalledWith(
+      {
+        unocss: {
+          strict: true,
+        },
+        settings: {
+          unocss: {
+            configPath: './preferred-uno.config.ts',
+          },
+        },
+      },
+      { name: 'preset' },
+    )
+  })
+
+  it('drops injected settings.unocss when unocss is disabled due to missing plugin', () => {
+    getPresetsMock.mockReturnValueOnce([
+      {
+        unocss: {
+          strict: true,
+          configPath: './uno.config.ts',
+        },
+        settings: {
+          unocss: {
+            configPath: './uno.config.ts',
+          },
+          foo: {
+            bar: true,
+          },
+        },
+      } as any,
+      { name: 'preset' },
+    ])
+    hasAllPackagesMock.mockImplementation((packages) => {
+      return !packages.includes('@unocss/eslint-plugin')
+    })
+
+    icebreaker({
+      unocss: {
+        strict: true,
+        configPath: './uno.config.ts',
+      },
+      settings: {
+        unocss: {
+          configPath: './uno.config.ts',
+        },
+        foo: {
+          bar: true,
+        },
+      },
+    } as any)
+
+    expect(antfuMock).toHaveBeenCalledWith(
+      {
+        unocss: false,
+        settings: {
+          foo: {
+            bar: true,
+          },
+        },
+      },
+      { name: 'preset' },
+    )
+  })
+
+  it('maps unocss.configPath to settings.unocss.configPath in legacy mode', () => {
+    getPresetsMock.mockReturnValueOnce([
+      {
+        unocss: {
+          strict: true,
+          configPath: './legacy-uno.config.ts',
+        },
+      } as any,
+      { name: 'preset' },
+    ])
+
+    icebreakerLegacy({
+      unocss: {
+        strict: true,
+        configPath: './legacy-uno.config.ts',
+      },
+    } as any)
+
+    expect(antfuMock).toHaveBeenCalledWith(
+      {
+        unocss: {
+          strict: true,
+        },
+        settings: {
+          unocss: {
+            configPath: './legacy-uno.config.ts',
+          },
+        },
+      },
+      { name: 'preset' },
+    )
+  })
+
+  it('disables unocss in legacy mode when the plugin is unavailable', () => {
+    getPresetsMock.mockReturnValueOnce([
+      {
+        unocss: true,
+      } as any,
+      { name: 'preset' },
+    ])
+    hasAllPackagesMock.mockImplementation((packages) => {
+      return !packages.includes('@unocss/eslint-plugin')
+    })
+
+    icebreakerLegacy({
+      unocss: true,
+    } as any)
+
+    expect(antfuMock).toHaveBeenCalledWith(
+      {
+        unocss: false,
+      },
+      { name: 'preset' },
+    )
+  })
 })

--- a/packages/eslint/test/peer-compat.unit.test.ts
+++ b/packages/eslint/test/peer-compat.unit.test.ts
@@ -29,6 +29,10 @@ const ANTFU_PEER_CHECK_PACKAGES = [
   'eslint-plugin-react-refresh',
 ] as const
 
+const OPTIONAL_UNOCSS_PACKAGES = [
+  '@unocss/eslint-plugin',
+] as const
+
 function readInstalledPackageJson(name: string): { version: string } {
   const packageJsonPath = path.join(
     PACKAGE_DIR,
@@ -52,7 +56,27 @@ describe('peer compatibility', () => {
     expect(packageJson.optionalDependencies?.[name]).toBeUndefined()
   })
 
+  it.each(OPTIONAL_UNOCSS_PACKAGES)('ships %s as an optional dependency', (name) => {
+    expect(packageJson.optionalDependencies?.[name]).toBeTruthy()
+    expect(packageJson.dependencies?.[name]).toBeUndefined()
+  })
+
   it.each(ANTFU_PEER_CHECK_PACKAGES)(
+    'keeps the installed %s version within the @antfu/eslint-config peer range',
+    (name) => {
+      const installedPackageJson = readInstalledPackageJson(name)
+      const peerRange = antfuPackageJson.peerDependencies?.[name]
+
+      expect(peerRange).toBeTruthy()
+      expect(
+        semver.satisfies(installedPackageJson.version, peerRange!, {
+          includePrerelease: true,
+        }),
+      ).toBe(true)
+    },
+  )
+
+  it.each(OPTIONAL_UNOCSS_PACKAGES)(
     'keeps the installed %s version within the @antfu/eslint-config peer range',
     (name) => {
       const installedPackageJson = readInstalledPackageJson(name)


### PR DESCRIPTION
 - add typed \unocss` wrapper options with `configPath`, `strict`, and `attributify``                                                                                                                    
  skip UnoCSS when `@unocss/eslint-plugin` is unavailable