### PR TITLE
fix(ci): migrate changesets action v2 inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,8 @@ jobs:
         id: changesets
         uses: changesets/action@v2
         with:
-          version: pnpm release:version
-          publish: pnpm release:publish
+          version-script: pnpm release:version
+          publish-script: pnpm release:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- migrate the Changesets action v2 inputs from `version`/`publish` to `version-script`/`publish-script`
- restore the release job after the dependency upgrade to `changesets/action@v2`

## Root cause

`changesets/action@v2` rejects the v1 input names before executing either release script. Run 31684857538 therefore failed immediately in the release step.

## Verification

- parsed `.github/workflows/release.yml` with the repository `yaml` dependency
- checked configured inputs against `changesets/action@v2` `action.yml`
- `pnpm lint`
- `git diff --check`

No changeset is required because this only repairs CI release orchestration and does not change a published package.